### PR TITLE
Add support for reading multiple position indices from a file

### DIFF
--- a/Userguide.md
+++ b/Userguide.md
@@ -140,6 +140,7 @@ more boundary conditions. The fundamental files are introduced in Table 1.
 | Other files: |  |  |
 | *times\_setup.dat* | Four values respectively indicate model start time, total time, output interval, and backup interval in seconds |  |
 | *device\_setup.dat* | Values to define the ID of GPU devices that used to run model in each subdomain. |  |
+| *position_indices.dat* | Position indices | Indices of positions to read water depth, flow rate, and flow velocity data from |
 
 *Note: The IntegratedShallowFlowSolver for landslide movement only requires the first three input files*
 


### PR DESCRIPTION
Add functionality to read multiple position indices from a file and obtain water depth data for each position.

* Modify `apps/cudaFloodSolver/cuda_flood_solver.cu` to read position indices from `input/position_indices.dat`, store them in a vector, and create output files for each monitoring point. Update the main loop to write water depth data for each position index to the corresponding output file.
* Update `lib/include/IO/cuda_gauges_writer.h` to handle multiple position indices. Modify the `write` function to write data for multiple position indices to separate output files.
* Ensure `lib/include/field/cuda_mapped_field.h` can handle the new position indices and provide the required data. Add a new function `get_data_for_indices` to retrieve data for the specified indices.
* Update `Userguide.md` to include instructions on how to use the new feature for reading multiple position indices from a file.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/liudh56/HiPIMS-ts/pull/1?shareId=76b7f35f-bdd2-423d-8447-9d636ab96845).